### PR TITLE
fix: Security bump of jquery

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6164,9 +6164,9 @@
       }
     },
     "jquery": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
-      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==",
       "dev": true
     },
     "js-reporters": {


### PR DESCRIPTION
Fixes following report:
```
Known moderate severity security vulnerability detected in jquery < 3.4.0 defined in package-lock.json.
package-lock.json update suggested: jquery ~> 3.4.0.
```